### PR TITLE
[PoC] Add writing interfaces

### DIFF
--- a/BinaryInterface.php
+++ b/BinaryInterface.php
@@ -16,9 +16,4 @@ interface BinaryInterface extends FileInterface
      * @return stream
      */
     public function getContentAsStream();
-
-    /**
-     * @param $stream
-     */
-    public function setContentFromStream($stream);
 }

--- a/BinaryWriteInterface.php
+++ b/BinaryWriteInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MediaBundle;
+
+/**
+ * Write interface definition for BinaryInterface.
+ */
+interface BinaryWriteInterface extends BinaryInterface
+{
+    /**
+     * @param $stream
+     */
+    public function setContentFromStream($stream);
+}

--- a/DirectoryWriteInterface.php
+++ b/DirectoryWriteInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MediaBundle;
+
+/**
+ * Write interface definition for DirectoryInterface.
+ */
+interface DirectoryWriteInterface extends DirectoryInterface
+{
+    /**
+     * Set the parent directory.
+     *
+     * @param DirectoryInterface $parent
+     *
+     * @return boolean
+     */
+    public function setParentDirectory(DirectoryInterface $parent);
+}

--- a/Doctrine/Phpcr/File.php
+++ b/Doctrine/Phpcr/File.php
@@ -12,8 +12,8 @@ use Symfony\Cmf\Bundle\MediaBundle\FileSystemInterface;
  * TODO: create and add cmf:file mixin
  * This class represents a CmfMedia Doctrine Phpcr file.
  */
-class File extends Media implements BinaryInterface,
-                                    DirectoryInterface
+class File extends Media implements BinaryWriteInterface,
+                                    DirectoryWriteInterface
 {
     /**
      * @var Resource

--- a/Doctrine/Phpcr/Image.php
+++ b/Doctrine/Phpcr/Image.php
@@ -8,7 +8,7 @@ use Symfony\Cmf\Bundle\MediaBundle\ImageInterface;
  * TODO: create and add cmf:image mixin
  * This class represents a CmfMedia Doctrine PHPCR image.
  */
-class Image extends File implements ImageInterface
+class Image extends File implements ImageWriteInterface
 {
     /**
      * @var int
@@ -21,7 +21,7 @@ class Image extends File implements ImageInterface
     protected $height;
 
     /**
-     * @param int $width
+     * {@inheritDoc}
      */
     public function setWidth($width)
     {
@@ -37,7 +37,7 @@ class Image extends File implements ImageInterface
     }
 
     /**
-     * @param int $height
+     * {@inheritDoc}
      */
     public function setHeight($height)
     {

--- a/FileInterface.php
+++ b/FileInterface.php
@@ -18,26 +18,6 @@ interface FileInterface extends MediaInterface
     public function getContentAsString();
 
     /**
-     * Set the content
-     *
-     * @param string $content
-     *
-     * @return boolean
-     */
-    public function setContentFromString($content);
-
-    /**
-     * Copy the content from a file, this allows to optimize copying the data
-     * of a file. It is preferred to use the dedicated content setters if
-     * possible.
-     *
-     * @param FileInterface|\SplFileInfo $file
-     *
-     * @throws \InvalidArgumentException if file is no FileInterface|\SplFileInfo
-     */
-    public function copyContentFromFile($file);
-
-    /**
      * Get the file size in bytes
      *
      * @return integer

--- a/FileWriteInterface.php
+++ b/FileWriteInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MediaBundle;
+
+/**
+ * Write interface definition for FileInterface.
+ *
+ * This is to be kept compatible with the SonataMediaBundle MediaInterface to
+ * allow integration with sonata.
+ */
+interface FileWriteInterface extends FileInterface, MediaWriteInterface
+{
+    /**
+     * Set the content
+     *
+     * @param string $content
+     *
+     * @return boolean
+     */
+    public function setContentFromString($content);
+
+    /**
+     * Copy the content from a file, this allows to optimize copying the data
+     * of a file. It is preferred to use the dedicated content setters if
+     * possible.
+     *
+     * @param FileInterface|\SplFileInfo $file
+     *
+     * @throws \InvalidArgumentException if file is no FileInterface|\SplFileInfo
+     */
+    public function copyContentFromFile($file);
+
+    /**
+     * Set the file size in bytes
+     *
+     * @return integer
+     */
+    public function setSize($size);
+
+    /**
+     * Set the mime type of this media element
+     *
+     * @return string
+     */
+    public function setContentType($contentType);
+}

--- a/Form/DataTransformer/ModelToFileTransformer.php
+++ b/Form/DataTransformer/ModelToFileTransformer.php
@@ -2,10 +2,8 @@
 
 namespace Symfony\Cmf\Bundle\MediaBundle\Form\DataTransformer;
 
-use Symfony\Cmf\Bundle\MediaBundle\BinaryInterface;
-use Symfony\Cmf\Bundle\MediaBundle\FileInterface;
+use Symfony\Cmf\Bundle\MediaBundle\FileWriteInterface;
 use Symfony\Component\Form\DataTransformerInterface;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ModelToFileTransformer implements DataTransformerInterface
@@ -15,6 +13,13 @@ class ModelToFileTransformer implements DataTransformerInterface
     public function __construct($class)
     {
         $this->dataClass = $class;
+
+        if (!is_subclass_of($class, 'Symfony\Cmf\Bundle\MediaBundle\FileWriteInterface')) {
+            throw new \InvalidArgumentException(sprintf(
+                'The class "%s" does not implement Symfony\Cmf\Bundle\MediaBundle\FileWriteInterface',
+                $class
+            ));
+        }
     }
 
     /**
@@ -26,7 +31,7 @@ class ModelToFileTransformer implements DataTransformerInterface
             return $uploadedFile;
         }
 
-        /** @var $file FileInterface */
+        /** @var $file FileWriteInterface */
         $file = new $this->dataClass;
         $file->copyContentFromFile($uploadedFile);
 

--- a/ImageWriteInterface.php
+++ b/ImageWriteInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MediaBundle;
+
+/**
+ * Write interface definition for ImageInterface.
+ *
+ * This is to be kept compatible with the SonataMediaBundle MediaInterface to
+ * allow integration with sonata.
+ */
+interface ImageWriteInterface extends ImageInterface, FileWriteInterface
+{
+    /**
+     * Set image width in pixels
+     *
+     * @return integer $width
+     */
+    public function setWidth($width);
+
+    /**
+     * Set image height in pixels
+     *
+     * @return integer $height
+     */
+    public function setHeight($height);
+}

--- a/MediaWriteInterface.php
+++ b/MediaWriteInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MediaBundle;
+
+/**
+ * Write interface definition for MediaInterface.
+ *
+ * This is to be kept compatible with the SonataMediaBundle MediaInterface to
+ * allow integration with sonata.
+ */
+interface MediaWriteInterface extends MediaInterface
+{
+    /**
+     * The name of this media, e.g. for managing media documents
+     *
+     * For example an image file name.
+     *
+     * @return string $name
+     */
+    public function setName($name);
+
+    /**
+     * The description to show to users, e.g. an image caption or some text
+     * to put after the filename.
+     *
+     * @return string $description
+     */
+    public function setDescription($description);
+
+    /**
+     * The copyright text, e.g. a license name
+     *
+     * @return string $copyright
+     */
+    public function setCopyright($copyright);
+
+    /**
+     * The name of the author of the media represented by this object
+     *
+     * @return string $authorName
+     */
+    public function setAuthorName($authorName);
+
+    /**
+     * Set all metadata
+     *
+     * @return array $metadata
+     */
+    public function setMetadata(array $metadata);
+
+    /**
+     * The metadata value
+     *
+     * @param string $name
+     * @param mixed  $value
+     */
+    public function setMetadataValue($name, $value);
+
+    /**
+     * Remove a named data from the metadata
+     *
+     * @param string $name
+     */
+    public function unsetMetadataValue($name);
+}

--- a/Model/Media.php
+++ b/Model/Media.php
@@ -2,9 +2,9 @@
 
 namespace Symfony\Cmf\Bundle\MediaBundle\Model;
 
-use Symfony\Cmf\Bundle\MediaBundle\MediaInterface;
+use Symfony\Cmf\Bundle\MediaBundle\MediaWriteInterface;
 
-class Media implements MediaInterface
+class Media implements MediaWriteInterface
 {
     /**
      * @var string
@@ -68,7 +68,7 @@ class Media implements MediaInterface
     }
 
     /**
-     * @param string $name
+     * {@inheritDoc}
      */
     public function setName($name)
     {
@@ -84,7 +84,7 @@ class Media implements MediaInterface
     }
 
     /**
-     * @param string $description
+     * {@inheritDoc}
      */
     public function setDescription($description)
     {
@@ -100,7 +100,7 @@ class Media implements MediaInterface
     }
 
     /**
-     * @param string $copyright
+     * {@inheritDoc}
      */
     public function setCopyright($copyright)
     {
@@ -116,7 +116,7 @@ class Media implements MediaInterface
     }
 
     /**
-     * @param string $authorName
+     * {@inheritDoc}
      */
     public function setAuthorName($authorName)
     {
@@ -132,9 +132,9 @@ class Media implements MediaInterface
     }
 
     /**
-     * @param array $metadata
+     * {@inheritDoc}
      */
-    public function setMetadata($metadata)
+    public function setMetadata(array $metadata)
     {
         $this->metadata = $metadata;
     }
@@ -156,12 +156,21 @@ class Media implements MediaInterface
     }
 
     /**
-     * @param string $name
-     * @param mixed  $value
+     * {@inheritDoc}
      */
     public function setMetadataValue($name, $value)
     {
         $this->metadata[$name] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unsetMetadataValue($name)
+    {
+        $metadata = $this->getMetadata();
+        unset($metadata[$name]);
+        $this->setMetadata($metadata);
     }
 
     /**


### PR DESCRIPTION
A proof-of-concept to see how it would look like for the MediaBundle. We have had a discussion about separating setters and getters on the weekly irc-meeting in general for other bundles.

These related PRs need to be updated if the writing interfaces will be used:
- symfony-cmf/BlockBundle#72
- symfony-cmf/CreateBundle#60

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets | na |
| License | MIT |
| Doc PR | TODO, the whole MediaBundle needs to be documented |
