### PR TITLE
Remove incorrect xml mapping path

### DIFF
--- a/CmfMediaBundle.php
+++ b/CmfMediaBundle.php
@@ -22,7 +22,6 @@ class CmfMediaBundle extends Bundle
             $container->addCompilerPass(
                 DoctrinePhpcrMappingsPass::createXmlMappingDriver(
                     array(
-                        realpath(__DIR__ . '/Resources/config/doctrine-model') => 'Symfony\Cmf\Bundle\MediaBundle\Model',
                         realpath(__DIR__ . '/Resources/config/doctrine-phpcr') => 'Symfony\Cmf\Bundle\MediaBundle\Doctrine\Phpcr',
                     ),
                     array('cmf_media.manager_name')


### PR DESCRIPTION
As the `Resources\config\doctrine-model` directory does not exist, the `realpath` method returns `false`, causing this exception :

```
[Doctrine\Common\Persistence\Mapping\MappingException]                                                  
File mapping drivers must have a valid directory path, however the given path 0 seems to be incorrect!
```
