### PR TITLE
Fix detect bundles in configuration

### DIFF
--- a/DependencyInjection/CmfMediaExtension.php
+++ b/DependencyInjection/CmfMediaExtension.php
@@ -57,7 +57,8 @@ class CmfMediaExtension extends Extension implements PrependExtensionInterface
         $config = $this->processConfiguration($configuration, $configs);
 
         // detect bundles
-        if ($config['use_imagine'] ||
+        $bundles = $container->getParameter('kernel.bundles');
+        if (true === $config['use_imagine'] ||
             ('auto' === $config['use_imagine'] && isset($bundles['LiipImagineBundle']))
         ) {
             $useImagine = true;
@@ -65,7 +66,7 @@ class CmfMediaExtension extends Extension implements PrependExtensionInterface
             $useImagine = false;
         }
 
-        if ($config['use_jms_serializer'] ||
+        if (true === $config['use_jms_serializer'] ||
             ('auto' === $config['use_jms_serializer'] && isset($bundles['JMSSerializerBundle']))
         ) {
             $useJmsSerializer = true;


### PR DESCRIPTION
As spotted by @wcluijt for the BlockBundle (https://github.com/symfony-cmf/BlockBundle/issues/121) the bundles are not detected correctly.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
