### PR TITLE
Do not limit path for displaying images + fix imagine config

### DIFF
--- a/Controller/ImageController.php
+++ b/Controller/ImageController.php
@@ -22,7 +22,7 @@ class ImageController extends FileController
     public function displayAction($path)
     {
         try {
-            $id = $this->mediaManager->mapUrlSafePathToId($path, $this->rootPath);
+            $id = $this->mediaManager->mapUrlSafePathToId($path);
         } catch (\OutOfBoundsException $e) {
             throw new NotFoundHttpException($e->getMessage());
         }

--- a/DependencyInjection/CmfMediaExtension.php
+++ b/DependencyInjection/CmfMediaExtension.php
@@ -127,7 +127,7 @@ class CmfMediaExtension extends Extension implements PrependExtensionInterface
 
     public function loadLiipImagine($enabled, $config, XmlFileLoader $loader, ContainerBuilder $container)
     {
-        if ($enabled) {
+        if (! $enabled) {
             $container->setParameter($this->getAlias() . '.use_imagine', false);
             $container->setParameter($this->getAlias() . '.imagine.filter', false);
             $container->setParameter($this->getAlias() . '.imagine.all_filters', array());


### PR DESCRIPTION
Found while testing https://github.com/symfony-cmf/BlockBundle/pull/125 that I broke the imagine configuration in a bundle standards refactor. This PR will fix this.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
