### PR TITLE
change prepend parameters for CmfCreateBundle to use semantic config

### DIFF
--- a/DependencyInjection/CmfMediaExtension.php
+++ b/DependencyInjection/CmfMediaExtension.php
@@ -37,8 +37,8 @@ class CmfMediaExtension extends Extension implements PrependExtensionInterface
                         'phpcr' => array(
                             'image' => array(
                                 'enabled'     => true,
-                                'model_class' => '%cmf_media.persistence.phpcr.image.class%',
-                                'basepath'    => '%cmf_media.persistence.phpcr.media_basepath%',
+                                'model_class' => $config['persistence']['phpcr']['image_class'],
+                                'basepath'    => $config['persistence']['phpcr']['media_basepath'],
                             ),
                         ),
                     ),


### PR DESCRIPTION
I've experienced the error:

`You have requested a non-existent parameter "cmf_media.persistence.phpcr.image.class".`

when compiling the container in an application that also contains the CmfCreateBundle.  The parameter references are resolved before the parameters are created from CmfMediaBundle's own semantic config.

I haven't dived far down this rabbit hole, but it looks to me as if the parameter references are being resolved too early when calling `prependExtensionConfig()` on the container builder (in which case, this would be an issue in the Symfony DependencyInjection component).

This PR short-circuits the issue by using the config from the CmfMediaBundle directly, rather than passing parameter references.  It solves my error, but please feed back if you think this is an incorrect approach.
