### PR TITLE
remove a TODO and cleanup DI configuration

### DIFF
--- a/DependencyInjection/CmfMediaExtension.php
+++ b/DependencyInjection/CmfMediaExtension.php
@@ -157,12 +157,12 @@ class CmfMediaExtension extends Extension implements PrependExtensionInterface
         }
 
         $filters = isset($config['extra_filters']) && is_array($config['extra_filters'])
-            ? array_merge($config['imagine_filter'], $config['extra_filters'])
+            ? array_merge($config['imagine_filters'], $config['extra_filters'])
             : array();
 
         $container->setParameter($this->getAlias() . '.use_imagine', true);
-        $container->setParameter($this->getAlias() . '.imagine.filter.upload_thumbnail', $config['imagine_filter']['upload_thumbnail']);
-        $container->setParameter($this->getAlias() . '.imagine.filter.elfinder_thumbnail', $config['imagine_filter']['elfinder_thumbnail']);
+        $container->setParameter($this->getAlias() . '.imagine.filter.upload_thumbnail', $config['imagine_filters']['upload_thumbnail']);
+        $container->setParameter($this->getAlias() . '.imagine.filter.elfinder_thumbnail', $config['imagine_filters']['elfinder_thumbnail']);
         $container->setParameter($this->getAlias() . '.imagine.all_filters', $filters);
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,13 +64,14 @@ class Configuration implements ConfigurationInterface
     private function addImageSection(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('imagine_filter')
             ->fixXmlConfig('extra_filter')
             ->children()
                 ->enumNode('use_imagine')
                     ->values(array(true, false, 'auto'))
                     ->defaultValue('auto')
                 ->end()
-                ->arrayNode('imagine_filter')
+                ->arrayNode('imagine_filters')
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('upload_thumbnail')->defaultValue('image_upload_thumbnail')->end()

--- a/EventListener/ImagineCacheInvalidatorSubscriber.php
+++ b/EventListener/ImagineCacheInvalidatorSubscriber.php
@@ -4,6 +4,7 @@ namespace Symfony\Cmf\Bundle\MediaBundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ODM\PHPCR\Document\Resource;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Symfony\Cmf\Bundle\MediaBundle\ImageInterface;
 use Symfony\Cmf\Bundle\MediaBundle\MediaManagerInterface;
@@ -94,13 +95,9 @@ class ImagineCacheInvalidatorSubscriber implements EventSubscriber
     private function invalidateCache(LifecycleEventArgs $args)
     {
         $object = $args->getObject();
-        // TODO: do we still need this?
-//        if ($document instanceof Resource) {
-//            $document = $document->getParent();
-//        }
-//        if ($document instanceof File) {
-//            $document = $document->getParent();
-//        }
+        if ($object instanceof Resource) {
+            $object = $object->getParent();
+        }
         if ($object instanceof ImageInterface) {
             if (! $this->container->isScopeActive('request')
                 || ! $request = $this->container->get('request')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes (imagine_filter to imagine_filters) |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

as imagine_filter has several children, i added the s but with a fixXmlConfig at least.
