### PR TITLE
handle file upload errors

### DIFF
--- a/File/UploadFileHelperInterface.php
+++ b/File/UploadFileHelperInterface.php
@@ -38,22 +38,26 @@ interface UploadFileHelperInterface
     /**
      * Get helper
      *
-     * @param $name leave null to get the default helper
+     * @param string $name leave null to get the default helper
      *
      * @return UploadEditorHelperInterface|null
      */
     public function getEditorHelper($name = null);
 
     /**
-     * Handle the UploadedFile and create a FileInterface object specified by
-     * the configured class.
+     * Handle the UploadedFile and create a FileInterface object.
+     *
+     * If $class is specified, an instance of that class should be created if
+     * possible. If $class is null, the implementation chooses a suitable
+     * class, e.g. through configuration.
      *
      * @param Request      $request
      * @param UploadedFile $uploadedFile
+     * @param string       $class        Optional class name for the file class to generate.
      *
      * @return FileInterface
      */
-    public function handleUploadedFile(UploadedFile $uploadedFile);
+    public function handleUploadedFile(UploadedFile $uploadedFile, $class = null);
 
     /**
      * Process upload and get a response

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -12,6 +12,8 @@
 
 namespace Symfony\Cmf\Bundle\MediaBundle\Form\Type;
 
+use Symfony\Cmf\Bundle\MediaBundle\File\UploadFileHelperDoctrine;
+use Symfony\Cmf\Bundle\MediaBundle\File\UploadFileHelperInterface;
 use Symfony\Cmf\Bundle\MediaBundle\Form\DataTransformer\ModelToFileTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -22,17 +24,20 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 class ImageType extends AbstractType
 {
     private $dataClass;
+    private $uploadFileHelper;
     private $useImagine;
     private $defaultFilter;
 
     /**
-     * @param string $class
-     * @param bool   $useImagine
-     * @param bool   $defaultFilter
+     * @param string                    $class
+     * @param UploadFileHelperInterface $uploadFileHelper
+     * @param bool                      $useImagine
+     * @param bool                      $defaultFilter
      */
-    public function __construct($class, $useImagine = false, $defaultFilter = false)
+    public function __construct($class, UploadFileHelperInterface $uploadFileHelper, $useImagine = false, $defaultFilter = false)
     {
         $this->dataClass = $class;
+        $this->uploadFileHelper = $uploadFileHelper;
         $this->useImagine = $useImagine;
         $this->defaultFilter = $this->useImagine ? $defaultFilter : false;
     }
@@ -49,7 +54,7 @@ class ImageType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $transformer = new ModelToFileTransformer($options['data_class']);
+        $transformer = new ModelToFileTransformer($this->uploadFileHelper, $options['data_class']);
         $builder->addModelTransformer($transformer);
     }
 

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -123,6 +123,7 @@
         <service id="cmf_media.form.type.image" class="%cmf_media.form.image.class%">
             <tag name="form.type" alias="cmf_media_image" />
             <argument>%cmf_media.persistence.phpcr.image.class%</argument>
+            <argument type="service" id="cmf_media.upload_file_helper" />
             <argument>%cmf_media.use_imagine%</argument>
             <argument>%cmf_media.imagine.filter.upload_thumbnail%</argument>
         </service>

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -1,7 +1,7 @@
 {% block cmf_media_image_widget %}
     {{ form_widget(form) }}
     {% block cmf_media_image_widget_preview %}
-        {% if form.vars.data and form.vars.data.id %}
+        {% if form.vars.data and form.vars.data.id is defined and form.vars.data.id %}
                 <img src="{{ cmf_media_display_url(form.vars.data, { imagine_filter : imagine_filter }) }}" alt="" {% if not imagine_filter %}width="100"{% endif %} />
         {% endif %}
     {% endblock %}

--- a/Tests/Unit/File/UploadFileHelperTest.php
+++ b/Tests/Unit/File/UploadFileHelperTest.php
@@ -97,14 +97,14 @@ class UploadFileHelperTest extends \PHPUnit_Framework_TestCase
                 'upload_error' => UPLOAD_ERR_OK,
                 'expected_exception' => array(
                     'symfony\component\httpfoundation\file\exception\uploadexception',
-                    'The file likely did not pass the is_uploaded_file() check',
+                    'The file "test.txt" was not uploaded due to an unknown error.',
                 ),
             )),
             array(array(
                 'upload_error' => UPLOAD_ERR_INI_SIZE,
                 'expected_exception' => array(
                     'symfony\component\httpfoundation\file\exception\uploadexception',
-                    'The uploaded file exceeds the upload_max_filesize directive in php.ini',
+                    'The file "test.txt" exceeds your upload_max_filesize ini directive (limit is ',
                 ),
             )),
             array(array()),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | - |
| Tests pass? | - |
| Fixed tickets | #79 |
| License | MIT |
| Doc PR | - |

When uploading files through a form, there is no error handling. I thought we could use the upload file helper from the form type as well. This at least now gives a message that something went wrong and makes the upload file field marked as the field with error. however, it only gives the generic "invalid value" hint and does not show the ecxeption i throw. is there a way to better control that and give the exact error message like "file too big"?
