### PR TITLE
do not allow to upload files if no firewall is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+* **2013-12-26**: 1.0 allowed everybody to edit content if there was no
+  firewall configured on a route. This version is more secure, preventing
+  editing if there is no firewall configured. If you want to allow everybody
+  to edit content, set `cmf_media.upload_file_role: false`.
+
 1.0.0
 -----
 

--- a/Controller/FileController.php
+++ b/Controller/FileController.php
@@ -52,8 +52,8 @@ class FileController
         MediaManagerInterface $mediaManager,
         UploadFileHelperInterface $uploadFileHelper,
         $requiredUploadRole,
-        SecurityContextInterface $securityContext = null)
-    {
+        SecurityContextInterface $securityContext = null
+    ) {
         $this->managerRegistry    = $registry;
         $this->managerName        = $managerName;
         $this->class              = $class === '' ? null : $class;
@@ -165,10 +165,29 @@ class FileController
      */
     public function uploadAction(Request $request)
     {
-        if ($this->securityContext && false === $this->securityContext->isGranted($this->requiredUploadRole)) {
-            throw new AccessDeniedException();
-        }
+        $this->checkSecurityUpload($request);
 
         return $this->uploadFileHelper->getUploadResponse($request);
+    }
+
+    /**
+     * Decide whether the user is allowed to upload a file.
+     *
+     * @throws AccessDeniedException if the current user is not allowed to
+     *      upload.
+     */
+    protected function checkSecurityUpload(Request $request)
+    {
+        if (false === $this->requiredUploadRole) {
+            return;
+        }
+        if ($this->securityContext
+            && $this->securityContext->getToken()
+            && $this->securityContext->isGranted($this->requiredUploadRole)
+        ) {
+            return;
+        }
+
+        throw new AccessDeniedException();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "target-dir": "Symfony/Cmf/Bundle/MediaBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | only edge cases |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | TODO |

The current code skips security checks if no symfony firewall is configured for the upload route. This fix limits this behaviour to when the user explicitly enables anonymous editing.
Also, we factor out the security check into a method to be more future proof.

/cc @rmsint
