### PR TITLE
Resolves #89 - Replace DIRECTORY_SEPERATOR constant with hardcoded "/"

### DIFF
--- a/Adapter/ElFinder/PhpcrDriver.php
+++ b/Adapter/ElFinder/PhpcrDriver.php
@@ -118,7 +118,7 @@ class PhpcrDriver extends ElFinderVolumeDriver
      **/
     protected function _joinPath($dir, $name)
     {
-        return $dir.DIRECTORY_SEPARATOR.$name;
+        return $dir."/".$name;
     }
 
     /**
@@ -195,7 +195,7 @@ class PhpcrDriver extends ElFinderVolumeDriver
      **/
     protected function _abspath($path)
     {
-        return $path == DIRECTORY_SEPARATOR ? $this->root : $this->root.DIRECTORY_SEPARATOR.$path;
+        return $path == "/" ? $this->root : $this->root."/".$path;
     }
 
     /**
@@ -220,7 +220,7 @@ class PhpcrDriver extends ElFinderVolumeDriver
      **/
     protected function _inpath($path, $parent)
     {
-        return $path == $parent || strpos($path, $parent.DIRECTORY_SEPARATOR) === 0;
+        return $path == $parent || strpos($path, $parent."/") === 0;
     }
 
     /**


### PR DESCRIPTION
Title says it all!

DIRECTORY_SEPARATOR is a PHP predefined constant which will result in a backslash on a windows machine. This caused problems when dealing with PHPCR objects since the paths in PHPCR always use a slash.
