### PR TITLE
remove invalid code in fixture loading reveiled by recent phpcr-odm cleaunp

### DIFF
--- a/Tests/Resources/DataFixtures/Phpcr/LoadMediaData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadMediaData.php
@@ -75,7 +75,6 @@ class LoadMediaData implements FixtureInterface, DependentFixtureInterface
         $content->setTitle('Content document with image embedded');
 
         $contentImage = new Image();
-        $contentImage->setName('cmf-logo.png');
         $contentImage->setFileContentFromFilesystem($testDataDir .'/cmf-logo.png');
 
         $content->setImage($contentImage);


### PR DESCRIPTION
This code made no sense as it was just ignored previously. Now that phcpr-odm checks and complains about this, we need to remove it.
