### PR TITLE
fix data_class and set file name in transformer

### DIFF
--- a/Form/DataTransformer/ModelToFileTransformer.php
+++ b/Form/DataTransformer/ModelToFileTransformer.php
@@ -48,6 +48,7 @@ class ModelToFileTransformer implements DataTransformerInterface
         /** @var $file FileInterface */
         $file = new $this->dataClass;
         $file->copyContentFromFile($uploadedFile);
+        $file->setName($uploadedFile->getClientOriginalName());
 
         return $file;
     }

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -49,7 +49,7 @@ class ImageType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $transformer = new ModelToFileTransformer($this->dataClass);
+        $transformer = new ModelToFileTransformer($options['data_class']);
         $builder->addModelTransformer($transformer);
     }
 


### PR DESCRIPTION
The data_class option of the ImageType was ignored. 
The transformer lost the original name of the file.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | [yes |
| Fixed tickets | n.a. |
| License | MIT |
| Doc PR | n.a. |
