### PR TITLE
limit to liip imagine version that works with the bundle.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "liip/imagine-bundle": "~0.12",
         "mikey179/vfsStream": "~1.2"
     },
+    "conflicts": {
+        "liip/imagine-bundle": ">=1.0"
+    },
     "suggest": {
         "symfony-cmf/core-bundle": "Simplifies configuration with other CMF bundles, use PHP >=5.3.9 with PHPCR",
         "knplabs/gaufrette": "When using the Gaufrette adapter",


### PR DESCRIPTION
if i understand composer correctly, this will prevent us from installing with the wrong version of the bundle.  fix #95
