### PR TITLE
Minor updates to PHPDoc blocks.

### DIFF
--- a/Adapter/ElFinder/PhpcrDriver.php
+++ b/Adapter/ElFinder/PhpcrDriver.php
@@ -17,6 +17,7 @@ use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\Document\Resource;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use FM\ElFinderPHP\Driver\ElFinderVolumeDriver;
+use Imagine\Filter\ FilterInterface;
 use PHPCR\Util\PathHelper;
 use Symfony\Cmf\Bundle\MediaBundle\DirectoryInterface;
 use Symfony\Cmf\Bundle\MediaBundle\Doctrine\Phpcr\Directory;
@@ -58,6 +59,7 @@ class PhpcrDriver extends ElFinderVolumeDriver
      * @param string                $managerName
      * @param MediaManagerInterface $mediaManager
      * @param CmfMediaHelper        $mediaHelper
+     * @param bool|FilterInterface  $imagineFilter
      */
     public function __construct(
         ManagerRegistry $registry,
@@ -352,7 +354,7 @@ class PhpcrDriver extends ElFinderVolumeDriver
      * Open file and return file pointer
      *
      * @param  string         $path  file path
-     * @param  bool           $write open file for writing
+     * @param  string         $mode  mode to use when opening file
      * @return resource|false
      * @author Dmitry (dio) Levashov
      **/

--- a/MediaInterface.php
+++ b/MediaInterface.php
@@ -38,6 +38,7 @@ interface MediaInterface
 
     /**
      * @param $name
+     *
      * @return void
      */
     public function setName($name);

--- a/MetadataInterface.php
+++ b/MetadataInterface.php
@@ -67,7 +67,9 @@ interface MetadataInterface extends MediaInterface
     /**
      * Set all metadata
      *
-     * @return array $metadata
+     * @param array $metadata
+     *
+     * @return mixed
      */
     public function setMetadata(array $metadata);
 
@@ -83,7 +85,7 @@ interface MetadataInterface extends MediaInterface
      * The metadata value
      *
      * @param string $name
-     * @param string  $value
+     * @param string $value
      */
     public function setMetadataValue($name, $value);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | - |
| New feature? | - |
| BC breaks? | - |
| Deprecations? | - |
| Tests pass? | - |
| Fixed tickets | - |
| License | - |
| Doc PR | - |

In documentation block for `Adapter\ElFinder\PhpcrDriver::_fopen`, the `$write` parameter has been renamed to `$mode`, to harmonize with the code. Note: The `$mode` parameter is never used in the method implementation.
Minor changes in `MetadataInterface` and `MediaInterface` documentation blocks.
