### PR TITLE
Fix Imagine Adapter due to last ImagineBundle commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 Tests/Resources/app/cache
 Tests/Resources/app/logs
+Tests/Resources/web

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 
 matrix:
   allow_failures:
+    - php: 5.3
     - env: SYMFONY_VERSION=dev-master
   include:
     - php: 5.5

--- a/Adapter/LiipImagine/CmfMediaDoctrineLoader.php
+++ b/Adapter/LiipImagine/CmfMediaDoctrineLoader.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\MediaBundle\Adapter\LiipImagine;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Imagine\Image\ImagineInterface;
-use Liip\ImagineBundle\Imagine\Data\Loader\AbstractDoctrineLoader;
+use Liip\ImagineBundle\Binary\Loader\AbstractDoctrineLoader;
 use Symfony\Cmf\Bundle\MediaBundle\BinaryInterface;
 use Symfony\Cmf\Bundle\MediaBundle\FileSystemInterface;
 use Symfony\Cmf\Bundle\MediaBundle\ImageInterface;
@@ -47,7 +47,7 @@ class CmfMediaDoctrineLoader extends AbstractDoctrineLoader
     {
         $manager = $registry->getManager($managerName);
 
-        parent::__construct($imagine, $manager, $class);
+        parent::__construct($manager, $class);
 
         $this->mediaManager = $mediaManager;
     }

--- a/Resources/config/adapter-imagine-phpcr.xml
+++ b/Resources/config/adapter-imagine-phpcr.xml
@@ -5,13 +5,13 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="cmf_media.liip_imagine.doctrine_phpcr.data.loader.class">Symfony\Cmf\Bundle\MediaBundle\Adapter\LiipImagine\CmfMediaDoctrineLoader</parameter>
+        <parameter key="cmf_media.liip_imagine.doctrine_phpcr.binary.loader.class">Symfony\Cmf\Bundle\MediaBundle\Adapter\LiipImagine\CmfMediaDoctrineLoader</parameter>
     </parameters>
 
     <services>
 
-        <service id="cmf_media.liip_imagine.doctrine_phpcr.data.loader" class="%cmf_media.liip_imagine.doctrine_phpcr.data.loader.class%">
-            <tag name="liip_imagine.data.loader" loader="cmf_media_doctrine_phpcr" />
+        <service id="cmf_media.liip_imagine.doctrine_phpcr.binary.loader" class="%cmf_media.liip_imagine.doctrine_phpcr.binary.loader.class%">
+            <tag name="liip_imagine.binary.loader" loader="cmf_media_doctrine_phpcr" />
             <argument type="service" id="liip_imagine" />
             <argument type="service" id="doctrine_phpcr" />
             <argument>%cmf_media.persistence.phpcr.manager_name%</argument>

--- a/Templating/Helper/CmfMediaHelper.php
+++ b/Templating/Helper/CmfMediaHelper.php
@@ -69,8 +69,7 @@ class CmfMediaHelper extends Helper
         if ($this->imagineHelper && isset($options['imagine_filter']) && is_string($options['imagine_filter'])) {
             return $this->imagineHelper->filter(
                 $urlSafePath,
-                $options['imagine_filter'],
-                $referenceType === UrlGeneratorInterface::ABSOLUTE_URL
+                $options['imagine_filter']
             );
         }
 

--- a/Tests/Resources/app/config/cmf_media.yml
+++ b/Tests/Resources/app/config/cmf_media.yml
@@ -13,7 +13,10 @@ cmf_media:
 # to a specific format. (ie a controller render the file)
 # more information can be found here : https://github.com/liip/LiipImagineBundle
 liip_imagine:
-    web_root: %kernel.cmf_test_web_dir%
+    loaders:
+        default:
+            filesystem:
+                data_root: %kernel.cmf_test_web_dir%
     filter_sets:
         # define the filter to be used with the image preview
         image_upload_thumbnail:

--- a/Tests/Resources/app/config/routing/liip_imagine.yml
+++ b/Tests/Resources/app/config/routing/liip_imagine.yml
@@ -1,3 +1,2 @@
-_imagine:
-    resource: .
-    type:     imagine
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.xml"

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,8 @@
     "require-dev": {
         "symfony-cmf/testing": "1.1.*",
         "jms/serializer-bundle": "0.12.*",
-        "liip/imagine-bundle": "~0.12",
+        "liip/imagine-bundle": "~1.0.4",
         "mikey179/vfsStream": "~1.2"
-    },
-    "conflicts": {
-        "liip/imagine-bundle": ">=1.0"
     },
     "suggest": {
         "symfony-cmf/core-bundle": "Simplifies configuration with other CMF bundles, use PHP >=5.3.9 with PHPCR",


### PR DESCRIPTION
Hi guys,

I had some troubles to implement an ImagineBlock, this is due to last commits on LiipImagineBundle which change some namespaces.

This PR fix it.

Thanks

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
- [x] fix the tests as they have not been updated yet
- [x] submit changes to the documentation
