### PR TITLE
fix imagine cache invalidation bug

### DIFF
--- a/Doctrine/ImagineCacheInvalidatorSubscriber.php
+++ b/Doctrine/ImagineCacheInvalidatorSubscriber.php
@@ -134,7 +134,7 @@ class ImagineCacheInvalidatorSubscriber implements EventSubscriber
         }
 
         foreach ($this->filters as $filter) {
-            $path = $this->manager->resolve($this->request, $this->mediaManager->getUrlSafePath($object), $filter);
+            $path = $this->manager->resolve($this->mediaManager->getUrlSafePath($object), $filter);
             if ($path instanceof RedirectResponse) {
                 $path = $path->getTargetUrl();
             }


### PR DESCRIPTION
Hi, 
i think there is a little bug in ImagineCacheInvalidatorSubscriber that prevent to save a block with a modified image.

There is an extra parameter on manager->resolve() call at line 137
The resolver doesn't wait for a Request.

Here is a little pull request to fix that

Find attached the stack trace of the generated error

Thanks

Xavier

[1] Sonata\AdminBundle\Exception\ModelManagerException: 
    at n/a
        in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/sonata-project/doctrine-phpcr-admin-bundle/Sonata/DoctrinePHPCRAdminBundle/Model/ModelManager.php line 94

```
at Sonata\DoctrinePHPCRAdminBundle\Model\ModelManager->update(object(HomePromoBlock))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/sonata-project/admin-bundle/Admin/Admin.php line 595

at Sonata\AdminBundle\Admin\Admin->update(object(HomePromoBlock))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/sonata-project/admin-bundle/Controller/CRUDController.php line 314

at Sonata\AdminBundle\Controller\CRUDController->editAction('lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1')
    in  line 

at call_user_func_array(array(object(CRUDController), 'editAction'), array('lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1'))
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 1087

at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), '1')
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 1049

at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), '1', true)
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 1198

at Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle(object(Request), '1', true)
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 448

at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
    in /Users/xav/Workspace/Sites/vhosts/redpill/web/app_dev.php line 41
```

[2] RuntimeException: Could not find configuration for a filter: lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1/image
    at n/a
        in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Filter/FilterConfiguration.php line 32

```
at Liip\ImagineBundle\Imagine\Filter\FilterConfiguration->get('lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1/image')
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Cache/CacheManager.php line 100

at Liip\ImagineBundle\Imagine\Cache\CacheManager->getResolver('lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1/image')
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/liip/imagine-bundle/Liip/ImagineBundle/Imagine/Cache/CacheManager.php line 197

at Liip\ImagineBundle\Imagine\Cache\CacheManager->resolve('', 'lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1/image', 'image_upload_thumbnail')
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/symfony-cmf/media-bundle/Doctrine/ImagineCacheInvalidatorSubscriber.php line 137

at Symfony\Cmf\Bundle\MediaBundle\Doctrine\ImagineCacheInvalidatorSubscriber->invalidateCache(object(LifecycleEventArgs))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/symfony-cmf/media-bundle/Doctrine/ImagineCacheInvalidatorSubscriber.php line 98

at Symfony\Cmf\Bundle\MediaBundle\Doctrine\ImagineCacheInvalidatorSubscriber->postUpdate(object(LifecycleEventArgs))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php line 61

at Symfony\Bridge\Doctrine\ContainerAwareEventManager->dispatchEvent('postUpdate', object(LifecycleEventArgs))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/Event/ListenersInvoker.php line 112

at Doctrine\ODM\PHPCR\Event\ListenersInvoker->invoke(object(ClassMetadata), 'postUpdate', object(Resource), object(LifecycleEventArgs), '4')
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/UnitOfWork.php line 2532

at Doctrine\ODM\PHPCR\UnitOfWork->executeUpdates(array('00000000277ff65d00000001763983cb' => object(HomePromoBlock), '00000000277ff8d700000001763983cb' => object(Resource)))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/UnitOfWork.php line 2065

at Doctrine\ODM\PHPCR\UnitOfWork->commit(null)
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/DocumentManager.php line 962

at Doctrine\ODM\PHPCR\DocumentManager->flush()
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/sonata-project/doctrine-phpcr-admin-bundle/Sonata/DoctrinePHPCRAdminBundle/Model/ModelManager.php line 92

at Sonata\DoctrinePHPCRAdminBundle\Model\ModelManager->update(object(HomePromoBlock))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/sonata-project/admin-bundle/Admin/Admin.php line 595

at Sonata\AdminBundle\Admin\Admin->update(object(HomePromoBlock))
    in /Users/xav/Workspace/Sites/vhosts/redpill/vendor/sonata-project/admin-bundle/Controller/CRUDController.php line 314

at Sonata\AdminBundle\Controller\CRUDController->editAction('lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1')
    in  line 

at call_user_func_array(array(object(CRUDController), 'editAction'), array('lesarcsb2c/cms/content/blocks/homepromos-container/homepromo-1'))
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 1087

at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), '1')
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 1049

at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), '1', true)
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 1198

at Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle(object(Request), '1', true)
    in /Users/xav/Workspace/Sites/vhosts/redpill/app/bootstrap.php.cache line 448

at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
    in /Users/xav/Workspace/Sites/vhosts/redpill/web/app_dev.php line 41
```
