### PR TITLE
Fix PHPCR 500 server error when media url has a trailing slash

### DIFF
--- a/Controller/ImageController.php
+++ b/Controller/ImageController.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\MediaBundle\Controller;
 use Symfony\Cmf\Bundle\MediaBundle\ImageInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
  * Controller to handle basic image actions that have a route
@@ -29,8 +30,12 @@ class ImageController extends FileController
     {
         try {
             $id = $this->mediaManager->mapUrlSafePathToId($path);
-        } catch (\OutOfBoundsException $e) {
-            throw new NotFoundHttpException($e->getMessage());
+        } catch (\Exception $e) {
+            if ($e instanceof ResourceNotFoundException || $e instanceof \OutOfBoundsException) {
+                throw new NotFoundHttpException($e->getMessage(), $e);
+            }
+
+            throw $e;
         }
 
         $contentObject = $this->getObjectManager()->find($this->class, $id);

--- a/Doctrine/Phpcr/MediaManager.php
+++ b/Doctrine/Phpcr/MediaManager.php
@@ -14,9 +14,11 @@ namespace Symfony\Cmf\Bundle\MediaBundle\Doctrine\Phpcr;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use PHPCR\RepositoryException;
 use PHPCR\Util\PathHelper;
 use Symfony\Cmf\Bundle\MediaBundle\MediaInterface;
 use Symfony\Cmf\Bundle\MediaBundle\MediaManagerInterface;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
  * A media manager suitable for doctrine phpcr-odm.
@@ -133,8 +135,12 @@ class MediaManager implements MediaManagerInterface
      */
     public function mapPathToId($path, $rootPath = null)
     {
-        // The path is being the id
-        $id = PathHelper::absolutizePath($path, '/');
+        try {
+            // The path is being the id
+            $id = PathHelper::absolutizePath($path, '/');
+        } catch (RepositoryException $e) {
+            throw new ResourceNotFoundException(sprintf('The PHPCR path "%s" is not valid', $path), 0, $e);
+        }
 
         if (is_string($rootPath) && 0 !== strpos($id, $rootPath)) {
             throw new \OutOfBoundsException(sprintf(

--- a/MediaManagerInterface.php
+++ b/MediaManagerInterface.php
@@ -10,6 +10,7 @@
  */
 
 namespace Symfony\Cmf\Bundle\MediaBundle;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
  * Interface containing media helper methods, these are probably persistence
@@ -77,8 +78,9 @@ interface MediaManagerInterface
      *
      * @return string
      *
-     * @throws \OutOfBoundsException if the path is out of the root path where
-     *                               the filesystem is located
+     * @throws ResourceNotFoundException if the path is invalid
+     * @throws \OutOfBoundsException     if the path is out of the root path where
+     *                                   the filesystem is located
      */
     public function mapUrlSafePathToId($path, $rootPath = null);
 }

--- a/Tests/Unit/Doctrine/Phpcr/MediaManagerTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/MediaManagerTest.php
@@ -144,14 +144,23 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/test/media/mymedia', $mediaManager->mapPathToId($path, $rootPath));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
-    public function testMapPathToIdException()
+    public function mapPathToIdExceptionProvider()
     {
-        $mediaManager = $this->getMediaManager();
+        return array(
+            array('/test/media/mymedia', '/out/of/bound', 'OutOfBoundsException'),
+            array('/test/', null, 'Symfony\Component\Routing\Exception\ResourceNotFoundException'),
+        );
+    }
 
-        $mediaManager->mapPathToId('/test/media/mymedia', '/out/of/bound');
+    /**
+     * @dataProvider mapPathToIdExceptionProvider
+     */
+    public function testMapPathToIdException($path, $rootPath, $exception)
+    {
+        $this->setExpectedException($exception);
+
+        $mediaManager = $this->getMediaManager();
+        $mediaManager->mapPathToId($path, $rootPath);
     }
 
     public function mapUrlSafePathToIdProvider()
@@ -172,13 +181,22 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/test/media/mymedia', $mediaManager->mapPathToId($path, $rootPath));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
-    public function testMapUrlSafePathToIdException()
+    public function mapUrlSafePathToIdExceptionProvider()
     {
-        $mediaManager = $this->getMediaManager();
+        return array(
+            array('test/media/mymedia', '/out/of/bound', 'OutOfBoundsException'),
+            array('/test/', null, 'Symfony\Component\Routing\Exception\ResourceNotFoundException'),
+        );
+    }
 
-        $mediaManager->mapUrlSafePathToId('test/media/mymedia', '/out/of/bound');
+    /**
+     * @dataProvider mapPathToIdExceptionProvider
+     */
+    public function testMapUrlSafePathToIdException($path, $rootPath, $exception)
+    {
+        $this->setExpectedException($exception);
+
+        $mediaManager = $this->getMediaManager();
+        $mediaManager->mapUrlSafePathToId($path, $rootPath);
     }
 }


### PR DESCRIPTION
When calling a media url with a trailing slash, like ``/media/image/cms/``, a ``PHPCR\RepositoryException`` is thrown with a ``Invalid path '/cms/' `` message, resulting in a 500 server error.