### PR TITLE
Fix failing PHP 5.3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*
   allow_failures:
-    - php: 5.3
     - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6

--- a/Tests/Unit/Doctrine/Phpcr/FileTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/FileTest.php
@@ -89,19 +89,23 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     public function copyContentFromFileProvider()
     {
+        $data = array();
         $testContent = 'Test file content.';
 
-        vfsStream::setup('home');
-        $fileSystemFile = vfsStream::url('home/test.txt');
-        file_put_contents($fileSystemFile, $testContent);
+        if (PHP_VERSION_ID >= 50400) {
+            // SplFileObject causes a segmentation fault in PHPunit in PHP 5.3.x
+            vfsStream::setup('home');
+            $fileSystemFile = vfsStream::url('home/test.txt');
+            file_put_contents($fileSystemFile, $testContent);
+
+            $data[] = array(new \SplFileObject($fileSystemFile), $testContent, 'text/plain', 18);
+        }
 
         $binaryFile = new File();
         $binaryFile->setContentFromString($testContent);
+        $data[] = array($binaryFile, $testContent, 'application/octet-stream', 18);
 
-        return array(
-            array(new \SplFileObject($fileSystemFile), $testContent, 'text/plain', 18),
-            array($binaryFile, $testContent, 'application/octet-stream', 18),
-        );
+        return $data;
     }
 
     /**


### PR DESCRIPTION
For some reason, `SplFileObject` causes trouble inside PHPunit's data provider handling. This PR ignores the test related to this object when testing against PHP 5.3. This is an improvement of the current state, which simply "ignores" PHP 5.3 tests completely.