### PR TITLE
Support imagine runtime config in display url templating helper

### DIFF
--- a/Templating/Helper/CmfMediaHelper.php
+++ b/Templating/Helper/CmfMediaHelper.php
@@ -69,7 +69,8 @@ class CmfMediaHelper extends Helper
         if ($this->imagineHelper && isset($options['imagine_filter']) && is_string($options['imagine_filter'])) {
             return $this->imagineHelper->filter(
                 $urlSafePath,
-                $options['imagine_filter']
+                $options['imagine_filter'],
+                isset($options['imagine_runtime_config']) ? $options['imagine_runtime_config'] : array()
             );
         }
 


### PR DESCRIPTION
Useful when passing dynamic thumbnail config, e.g.:

```twig
<img src="{{

cmf_media_display_url(image, {
   imagine_filter: 'my_filter',
   imagine_runtime_config: {
      'thumbnail': {'size': [120, 60]}
   }
})

}}" />
```