### PR TITLE
fix metadata PHPCR configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.3.0
+-----
+
+* **2016-02-5**: Fixed node type definition for metadata in the PHPCR File documents.
+  If you saw errors with metadata, you can update the node definitions. (in jackalope-
+  jackrabbit that requires exporting a database dump and creating a new repository.)
+
 1.2.0-RC1
 ---------
 

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -40,8 +40,9 @@
   - description (string)
   - copyright (string)
   - authorName (string)
-  - metadata (string)
-  - metadataKeys (string)
+  - metadata (string) multiple
+  - metadataKeys (string) multiple
+  - metadataNulls (string) multiple
 
 [cmf:image] > cmf:media mixin
   - width (long) mandatory

--- a/Tests/Resources/Controller/PhpcrImageTestController.php
+++ b/Tests/Resources/Controller/PhpcrImageTestController.php
@@ -121,7 +121,9 @@ class PhpcrImageTestController extends Controller
 
             $uploadedFile = $request->files->get('image');
 
+            /** @var Image $image */
             $image = $uploadImageHelper->handleUploadedFile($uploadedFile);
+            $image->setMetadataValue('a', 'b');
 
             // persist
             $dm = $this->get('doctrine_phpcr')->getManager('default');


### PR DESCRIPTION
fix #123

it was relatively easy to find once i had done https://github.com/jackalope/jackalope/pull/306 to see what actually goes on. probably was not noticed when originally developped as we only introduced node type validation in jackalope-doctrine-dbal at some later point.