### PR TITLE
_chmod method of ElFinderVolumeDriver is not implemented

### DIFF
--- a/Adapter/ElFinder/PhpcrDriver.php
+++ b/Adapter/ElFinder/PhpcrDriver.php
@@ -704,4 +704,17 @@ class PhpcrDriver extends ElFinderVolumeDriver
     {
         // TODO: Implement _checkArchivers() method.
     }
+
+    /**
+     * Change file mode (chmod)
+     *
+     * @param  string  $path  file path
+     * @param  string  $mode  octal string such as '0755'
+     *
+     * @author David Bartle,
+     **/
+    protected function _chmod($path, $mode)
+    {
+        // TODO: Implement _chmod() method.
+    }
 }

--- a/Adapter/ElFinder/PhpcrDriver.php
+++ b/Adapter/ElFinder/PhpcrDriver.php
@@ -706,10 +706,10 @@ class PhpcrDriver extends ElFinderVolumeDriver
     }
 
     /**
-     * Change file mode (chmod)
+     * Change file mode (chmod).
      *
-     * @param  string  $path  file path
-     * @param  string  $mode  octal string such as '0755'
+     * @param string $path file path
+     * @param string $mode octal string such as '0755'
      *
      * @author David Bartle,
      **/


### PR DESCRIPTION
New method `_chmod` has been added to  [ElFinderVolumeDriver](https://github.com/helios-ag/ElFinderPHP/blob/master/src/Driver/ElFinderVolumeDriver.php) so I implemented this method to `PhpcrDriver`